### PR TITLE
Chore/update peer dependencies

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -24,16 +24,16 @@
     "update:eslint-docs": "eslint-doc-generator"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": ">=5",
-    "eslint": ">=8",
-    "eslint-plugin-jest": ">=27.2.2",
-    "eslint-plugin-jest-formatting": ">=3.1.0",
-    "eslint-plugin-prettier": ">=4.2.1",
-    "eslint-plugin-react": ">=7.31.11",
-    "eslint-plugin-react-hooks": ">=4.6.0",
-    "eslint-plugin-react-native": ">=4.0.0",
-    "eslint-plugin-testing-library": ">=5.11.0",
-    "prettier": ">=2.8.8"
+    "@typescript-eslint/eslint-plugin": "^5.61.0",
+    "eslint": "^8.44.0",
+    "eslint-plugin-jest": "^27.2.2",
+    "eslint-plugin-jest-formatting": "^3.1.0",
+    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-react": "^7.31.11",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-native": "^4.0.0",
+    "eslint-plugin-testing-library": "^5.11.0",
+    "prettier": "^2.8.8"
   },
   "dependencies": {
     "@typescript-eslint/parser": "^5.48.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2538,7 +2538,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^5.48.0":
+"@typescript-eslint/eslint-plugin@^5.48.0", "@typescript-eslint/eslint-plugin@^5.61.0":
   version "5.61.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.61.0.tgz#a1a5290cf33863b4db3fb79350b3c5275a7b1223"
   integrity sha512-A5l/eUAug103qtkwccSCxn8ZRwT+7RXWkFECdA4Cvl1dOlDUgTpAOfSEElZn2uSUxhdDpnCdetrf0jvU4qrL+g==


### PR DESCRIPTION
Update peer dependencies versions 

Correct bug for `>= X.Y.Z` versions dependencies: some versions of `install-peerdeps` does not support this syntax