### PR TITLE
Feat/rule image requires accessible prop

### DIFF
--- a/example-app/.eslintrc
+++ b/example-app/.eslintrc
@@ -8,6 +8,7 @@
     }
   ],
   "rules": {
-    "@bam.tech/require-named-effect": "error"
+    "@bam.tech/require-named-effect": "error",
+    "@bam.tech/image-requires-accessible-prop": "error"
   }
 }

--- a/example-app/eslint-breaking-examples/break-image-requires-accessible-prop.tsx
+++ b/example-app/eslint-breaking-examples/break-image-requires-accessible-prop.tsx
@@ -1,0 +1,18 @@
+import { Image } from "react-native";
+
+const MyComponent = () => {
+  return (
+    <>
+      <Image source={{ uri: "" }} accessible accessibilityIgnoresInvertColors />
+      <Image source={{ uri: "" }} accessible accessibilityIgnoresInvertColors />
+      <Image source={{ uri: "random" }} accessibilityIgnoresInvertColors />
+      <OtherImage source={{ uri: "random" }} accessibilityIgnoresInvertColors />
+      <OtherImage source={{ uri: "random" }} accessibilityIgnoresInvertColors>
+        <></>
+      </OtherImage>
+    </>
+  );
+};
+
+const OtherImage = Image;
+export default MyComponent;

--- a/example-app/eslint-breaking-examples/break-image-requires-accessible-prop.tsx
+++ b/example-app/eslint-breaking-examples/break-image-requires-accessible-prop.tsx
@@ -9,8 +9,6 @@ const MyComponent = () => {
   return (
     <>
       <Image source={{ uri: "" }} accessibilityIgnoresInvertColors />
-      <Image source={{ uri: "" }} accessibilityIgnoresInvertColors />
-      <Image source={{ uri: "random" }} accessibilityIgnoresInvertColors />
       <OtherImage source={{ uri: "random" }} accessibilityIgnoresInvertColors />
       <NotReallyAnImage></NotReallyAnImage>
     </>

--- a/example-app/eslint-breaking-examples/break-image-requires-accessible-prop.tsx
+++ b/example-app/eslint-breaking-examples/break-image-requires-accessible-prop.tsx
@@ -1,18 +1,22 @@
-import { Image } from "react-native";
+// Save without formatting: [⌘ + K] > [S]
+
+// This should trigger an error breaking eslint-plugin-bam-custom-rules:
+// bam-custom-rules/image-requires-accessible-prop
+
+import { Image, View } from "react-native";
 
 const MyComponent = () => {
   return (
     <>
-      <Image source={{ uri: "" }} accessible accessibilityIgnoresInvertColors />
-      <Image source={{ uri: "" }} accessible accessibilityIgnoresInvertColors />
+      <Image source={{ uri: "" }} accessibilityIgnoresInvertColors />
+      <Image source={{ uri: "" }} accessibilityIgnoresInvertColors />
       <Image source={{ uri: "random" }} accessibilityIgnoresInvertColors />
       <OtherImage source={{ uri: "random" }} accessibilityIgnoresInvertColors />
-      <OtherImage source={{ uri: "random" }} accessibilityIgnoresInvertColors>
-        <></>
-      </OtherImage>
+      <NotReallyAnImage></NotReallyAnImage>
     </>
   );
 };
 
 const OtherImage = Image;
+const NotReallyAnImage = View;
 export default MyComponent;

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -54,9 +54,13 @@ This plugin exports some custom rules that you can optionally use in your projec
 
 <!-- begin auto-generated rules list -->
 
-| Name                                                       | Description                                            |
-| :--------------------------------------------------------- | :----------------------------------------------------- |
-| [require-named-effect](docs/rules/require-named-effect.md) | Enforces the use of named functions inside a useEffect |
+🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+
+| Name                                                                           | Description                                            | 🔧  | 💡  |
+| :----------------------------------------------------------------------------- | :----------------------------------------------------- | :-- | :-- |
+| [image-requires-accessible-prop](docs/rules/image-requires-accessible-prop.md) | Require accessible prop on image components            | 🔧  | 💡  |
+| [require-named-effect](docs/rules/require-named-effect.md)                     | Enforces the use of named functions inside a useEffect |     |     |
 
 <!-- end auto-generated rules list -->
 
@@ -67,7 +71,8 @@ To use a rule, just declare it in your `.eslintrc`:
 {
   "plugins": ["@bam.tech"],
   "rules": {
-    "@bam.tech/require-named-effect": "error"
+    "@bam.tech/require-named-effect": "error",
+    "@bam.tech/image-requires-accessible-prop": "error"
   }
 }
 ```

--- a/packages/eslint-plugin/docs/rules/image-requires-accessible-prop.md
+++ b/packages/eslint-plugin/docs/rules/image-requires-accessible-prop.md
@@ -1,6 +1,12 @@
-# Image requires an accessible prop (`image-requires-accessible-prop`)
+# Require accessible prop on image components (`@bam.tech/image-requires-accessible-prop`)
 
-Force to use an accessible prop on an image.
+🔧💡 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+
+<!-- end auto-generated rule header -->
+
+Enforces to use an accessible prop on an image.
+
+🔧💡 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
 ## Rule Details
 

--- a/packages/eslint-plugin/docs/rules/image-requires-accessible-prop.md
+++ b/packages/eslint-plugin/docs/rules/image-requires-accessible-prop.md
@@ -1,0 +1,29 @@
+# Image requires an accessible prop (`image-requires-accessible-prop`)
+
+Force to use an accessible prop on an image.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<Image source={{ uri: "" }} />
+```
+
+```jsx
+<BackgroundImage source={{ uri: "" }} />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<Image source={{ uri: "" }} accessible />
+```
+
+```jsx
+<BackgroundImage source={{ uri: "" }} accessible={false} />
+```
+
+## Further Reading
+
+This rule is only relevant if all your image components are suffixed with `Image`. If the component has children, it won't trigger an error to avoid confusion with containers.

--- a/packages/eslint-plugin/lib/rules/image-requires-accessible-prop.js
+++ b/packages/eslint-plugin/lib/rules/image-requires-accessible-prop.js
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Image requires an accessible prop
+ * @author Paul Briand
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: "problem", // `problem`, `suggestion`, or `layout`
+    docs: {
+      description: "Require accessible prop on image components",
+      recommended: false,
+      url: "https://github.com/bamlab/react-native-project-config/tree/main/packages/eslint-plugin/docs/rules/image-requires-accessible-prop.md", // URL to the documentation page for this rule
+    },
+    fixable: null, // Or `code` or `whitespace`
+    schema: [], // Add a schema if the rule has options
+    messages: {
+      imageRequiresAccessibleProp: "Image components require accessible prop ",
+    },
+  },
+
+  create(context) {
+    return {
+      JSXOpeningElement: (node) => {
+        if (
+          isImage(node) &&
+          !node.attributes.some((attr) => attr.name.name === "accessible")
+        ) {
+          context.report({
+            node,
+            messageId: "imageRequiresAccessibleProp",
+          });
+        }
+      },
+    };
+  },
+};
+
+const isImage = require("../utils/isImage");

--- a/packages/eslint-plugin/lib/rules/image-requires-accessible-prop.js
+++ b/packages/eslint-plugin/lib/rules/image-requires-accessible-prop.js
@@ -20,7 +20,7 @@ module.exports = {
     fixable: null, // Or `code` or `whitespace`
     schema: [], // Add a schema if the rule has options
     messages: {
-      imageRequiresAccessibleProp: "Image components require accessible prop ",
+      imageRequiresAccessibleProp: "Image components require accessible prop",
     },
   },
 

--- a/packages/eslint-plugin/lib/rules/image-requires-accessible-prop.js
+++ b/packages/eslint-plugin/lib/rules/image-requires-accessible-prop.js
@@ -11,22 +11,25 @@
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
+    hasSuggestions: true,
     type: "problem", // `problem`, `suggestion`, or `layout`
     docs: {
       description: "Require accessible prop on image components",
       recommended: false,
       url: "https://github.com/bamlab/react-native-project-config/tree/main/packages/eslint-plugin/docs/rules/image-requires-accessible-prop.md", // URL to the documentation page for this rule
     },
-    fixable: null, // Or `code` or `whitespace`
+    fixable: "code", // Or `code` or `whitespace`
     schema: [], // Add a schema if the rule has options
     messages: {
       imageRequiresAccessibleProp: "Image components require accessible prop",
+      suggestAddingAccessibleProp: "Add accessible prop",
     },
   },
 
   create(context) {
     return {
       JSXOpeningElement: (node) => {
+        console.log(node);
         if (
           isImage(node) &&
           !node.attributes.some((attr) => attr.name.name === "accessible")
@@ -34,6 +37,18 @@ module.exports = {
           context.report({
             node,
             messageId: "imageRequiresAccessibleProp",
+            suggest: [
+              {
+                messageId: "suggestAddingAccessibleProp",
+                fix: (fixer) => {
+                  const openingTagEnd = node.range[1];
+                  return fixer.insertTextBeforeRange(
+                    [openingTagEnd - (node.selfClosing ? 2 : 1), openingTagEnd],
+                    " accessible={true}"
+                  );
+                },
+              },
+            ],
           });
         }
       },

--- a/packages/eslint-plugin/lib/utils/isImage.js
+++ b/packages/eslint-plugin/lib/utils/isImage.js
@@ -1,0 +1,16 @@
+module.exports = (element) => {
+  if (element.type === "JSXOpeningElement") {
+    if (
+      element.name.type == "JSXIdentifier" &&
+      element.name.name.endsWith("Image")
+    ) {
+      if (element.parent && element.parent.children.length > 0) {
+        return false;
+      }
+
+      return true;
+    }
+  }
+
+  return false;
+};

--- a/packages/eslint-plugin/tests/lib/rules/image-requires-accessible-prop.js
+++ b/packages/eslint-plugin/tests/lib/rules/image-requires-accessible-prop.js
@@ -1,0 +1,45 @@
+/**
+ * @fileoverview Image requires an accessible prop
+ * @author Paul Briand
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/image-requires-accessible-prop"),
+  RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+const ruleTester = new RuleTester({
+  parser: require.resolve("@typescript-eslint/parser"),
+  parserOptions: {
+    ecmaVersion: 2021,
+    sourceType: "module",
+    ecmaFeatures: {
+      jsx: true, // This is the key line
+    },
+  },
+});
+
+const valid = [
+  `<Image source={{uri:""}} accessible />`,
+  `<BackgroundImage source={{uri:""}} accessible={false} />`,
+];
+
+const invalid = [
+  `<Image source={{uri:""}} />`,
+  `<BackgroundImage source={{uri:""}} />`,
+];
+
+ruleTester.run("image-requires-accessible-prop", rule, {
+  valid,
+
+  invalid: invalid.map((code) => ({
+    code,
+    errors: ["Image components require accessible prop"],
+  })),
+});

--- a/packages/eslint-plugin/tests/lib/rules/image-requires-accessible-prop.js
+++ b/packages/eslint-plugin/tests/lib/rules/image-requires-accessible-prop.js
@@ -20,7 +20,7 @@ const ruleTester = new RuleTester({
     ecmaVersion: 2021,
     sourceType: "module",
     ecmaFeatures: {
-      jsx: true, // This is the key line
+      jsx: true,
     },
   },
 });


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/m33/Rule-A1-image-requires-accessible-prop-260b37749bfc4996a886e528f6067e0d?pvs=4)

# Why? (@alexisdelage)

D’un point de vue accessibilité, une image peut se retrouver dans 2 cas :

- soit l’image apporte une information et doit être rendue accessible : dans ce cas, on ajoute `accessible={true}` (d’autres règles viendront forcer l’ajout d’un label et d’un rôle)
- soit c’est une image d’illustration, qui n’a pas besoin d’être lue par les lecteurs d’écrans : dans ce cas, on force l’ajout de `accessible={false}` (qui est la valeur par défaut) pour affirmer qu’il s’agit d’une image d’illustration