### PR TITLE
Feat/rule requires accessibility label

### DIFF
--- a/example-app/.eslintrc
+++ b/example-app/.eslintrc
@@ -12,6 +12,7 @@
     "@bam.tech/image-requires-accessible-prop": "error",
     "@bam.tech/do-not-use-role-on-image": "error",
     "@bam.tech/accessibility-props-require-accessible": "error",
-    "@bam.tech/requires-accessibility-role-when-accessible": "error"
+    "@bam.tech/requires-accessibility-role-when-accessible": "error",
+    "@bam.tech/requires-accessibility-label": "error"
   }
 }

--- a/example-app/eslint-breaking-examples/break-accessible-requires-accessibilityLabel.tsx
+++ b/example-app/eslint-breaking-examples/break-accessible-requires-accessibilityLabel.tsx
@@ -1,0 +1,20 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable react-native-a11y/has-valid-accessibility-ignores-invert-colors */
+// Save without formatting: [⌘ + K] > [S]
+
+// This should trigger an error breaking eslint-plugin-bam-custom-rules:
+// bam-custom-rules/requires-accessibility-label
+
+import { Text, View } from "react-native";
+
+export const MyComponent = () => {
+  return (
+    <>
+      <View accessible />
+      <View accessible>
+        <View accessibilityLabel="" />
+        <Text>this is a text</Text>
+      </View>
+    </>
+  );
+};

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -64,6 +64,7 @@ This plugin exports some custom rules that you can optionally use in your projec
 | [image-requires-accessible-prop](docs/rules/image-requires-accessible-prop.md)                           | Require accessible prop on image components                     | 🔧  | 💡  |
 | [require-named-effect](docs/rules/require-named-effect.md)                                               | Enforces the use of named functions inside a useEffect          |     |     |
 | [requires-accessibility-role-when-accessible](docs/rules/requires-accessibility-role-when-accessible.md) | Enforces accessibilityRole or role when component is accessible |     | 💡  |
+| [requires-accessibility-label](docs/rules/requires-accessibility-label.md)                               | Enforces label when component accessible                        |     |     |
 
 <!-- end auto-generated rules list -->
 
@@ -78,7 +79,8 @@ To use a rule, just declare it in your `.eslintrc`:
     "@bam.tech/image-requires-accessible-prop": "error",
     "@bam.tech/do-not-use-role-on-image": "error",
     "@bam.tech/accessibility-props-require-accessible": "error",
-    "@bam.tech/requires-accessibility-role-when-accessible": "error"
+    "@bam.tech/requires-accessibility-role-when-accessible": "error",
+    "@bam.tech/requires-accessibility-label": "error"
   }
 }
 ```

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -63,9 +63,8 @@ This plugin exports some custom rules that you can optionally use in your projec
 | [do-not-use-role-on-image](docs/rules/do-not-use-role-on-image.md)                                       | Disallow role prop on Image component                           | 🔧  |     |
 | [image-requires-accessible-prop](docs/rules/image-requires-accessible-prop.md)                           | Require accessible prop on image components                     | 🔧  | 💡  |
 | [require-named-effect](docs/rules/require-named-effect.md)                                               | Enforces the use of named functions inside a useEffect          |     |     |
-| [requires-accessibility-role-when-accessible](docs/rules/requires-accessibility-role-when-accessible.md) | Enforces accessibilityRole or role when component is accessible |     | 💡  |
-| [requires-accessibility-label](docs/rules/requires-accessibility-label.md)                               | Enforces label when component accessible                        |     |     |
 | [requires-accessibility-label](docs/rules/requires-accessibility-label.md)                               | Enforces label when component accessible                        |     | 💡  |
+| [requires-accessibility-role-when-accessible](docs/rules/requires-accessibility-role-when-accessible.md) | Enforces accessibilityRole or role when component is accessible |     | 💡  |
 
 <!-- end auto-generated rules list -->
 

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -65,6 +65,7 @@ This plugin exports some custom rules that you can optionally use in your projec
 | [require-named-effect](docs/rules/require-named-effect.md)                                               | Enforces the use of named functions inside a useEffect          |     |     |
 | [requires-accessibility-role-when-accessible](docs/rules/requires-accessibility-role-when-accessible.md) | Enforces accessibilityRole or role when component is accessible |     | 💡  |
 | [requires-accessibility-label](docs/rules/requires-accessibility-label.md)                               | Enforces label when component accessible                        |     |     |
+| [requires-accessibility-label](docs/rules/requires-accessibility-label.md)                               | Enforces label when component accessible                        |     | 💡  |
 
 <!-- end auto-generated rules list -->
 

--- a/packages/eslint-plugin/docs/rules/requires-accessibility-label.md
+++ b/packages/eslint-plugin/docs/rules/requires-accessibility-label.md
@@ -1,5 +1,7 @@
 # Enforces label when component accessible (`@bam.tech/requires-accessibility-label`)
 
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+
 <!-- end auto-generated rule header -->
 
 Please describe the origin of the rule here.

--- a/packages/eslint-plugin/docs/rules/requires-accessibility-label.md
+++ b/packages/eslint-plugin/docs/rules/requires-accessibility-label.md
@@ -1,0 +1,34 @@
+# Enforces label when component accessible (`@bam.tech/requires-accessibility-label`)
+
+<!-- end auto-generated rule header -->
+
+Please describe the origin of the rule here.
+
+## Rule Details
+
+This rule aims to...
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<View accessible />
+```
+
+```jsx
+<View accessible>
+  <Text>foo</Text>
+  <View accessible accessibilityLabel="foo" />
+</View>
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<View accessible accessibilityLabel="foo" />
+```
+
+```jsx
+<View accessible>
+  <Text>foo</Text>
+</View>
+```

--- a/packages/eslint-plugin/lib/rules/requires-accessibility-label.js
+++ b/packages/eslint-plugin/lib/rules/requires-accessibility-label.js
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Enforces label when component accessible
+ * @author Paul Briand
+ */
+"use strict";
+
+const hasLabelProp = require("../utils/hasLabelProp");
+const isAccessible = require("../utils/isAccessible");
+const isText = require("../utils/isText");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: "problem", // `problem`, `suggestion`, or `layout`
+    docs: {
+      description: "Enforces label when component accessible",
+      recommended: false,
+      url: "https://github.com/bamlab/react-native-project-config/tree/main/packages/eslint-plugin/docs/rules/requires-accessibility-label.md", // URL to the documentation page for this rule
+    },
+    fixable: null, // Or `code` or `whitespace`
+    schema: [], // Add a schema if the rule has options
+    messages: {
+      requiresAccessibilityLabel: "Requires accessibilityLabel",
+    },
+  },
+
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        if (isAccessible(node) && !isText(node)) {
+          if (
+            !node.attributes.some((attribute) =>
+              ["accessibilityLabel", "aria-label", "alt"].includes(
+                attribute.name.name
+              )
+            ) &&
+            !hasExactlyOneChildWhichIsTextOrHasALabel(node.parent)
+          ) {
+            context.report({
+              node,
+              messageId: "requiresAccessibilityLabel",
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+const hasExactlyOneChildWhichIsTextOrHasALabel = (node) => {
+  if (node.type === "JSXElement") {
+    return (
+      node.children.filter(
+        (child) =>
+          child.type === "JSXElement" &&
+          (isText(child.openingElement) || hasLabelProp(child.openingElement))
+      ).length === 1
+    );
+  }
+};

--- a/packages/eslint-plugin/lib/rules/requires-accessibility-label.js
+++ b/packages/eslint-plugin/lib/rules/requires-accessibility-label.js
@@ -34,10 +34,7 @@ module.exports = {
     return {
       JSXOpeningElement(node) {
         if (isAccessible(node) && !isText(node)) {
-          if (
-            !hasLabelProp(node) &&
-            !hasExactlyOneChildWhichIsTextOrHasALabel(node.parent)
-          ) {
+          if (!hasLabelProp(node) && !hasOneLabeledChild(node.parent)) {
             context.report({
               node,
               messageId: "requiresAccessibilityLabel",
@@ -64,14 +61,19 @@ module.exports = {
   },
 };
 
-const hasExactlyOneChildWhichIsTextOrHasALabel = (node) => {
+const hasOneLabeledChild = (node) => {
   if (node.type === "JSXElement") {
-    return (
-      node.children.filter(
-        (child) =>
-          child.type === "JSXElement" &&
-          (isText(child.openingElement) || hasLabelProp(child.openingElement))
-      ).length === 1
+    const JSXChildren = node.children.filter(
+      (child) => child.type === "JSXElement"
     );
+    if (JSXChildren.length === 1) {
+      return (
+        isLabeledComponent(JSXChildren[0].openingElement) ||
+        hasOneLabeledChild(JSXChildren[0])
+      );
+    }
   }
 };
+
+const isLabeledComponent = (element) =>
+  isText(element) || hasLabelProp(element);

--- a/packages/eslint-plugin/lib/rules/requires-accessibility-label.js
+++ b/packages/eslint-plugin/lib/rules/requires-accessibility-label.js
@@ -15,6 +15,7 @@ const isText = require("../utils/isText");
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
+    hasSuggestions: true,
     type: "problem", // `problem`, `suggestion`, or `layout`
     docs: {
       description: "Enforces label when component accessible",
@@ -25,6 +26,7 @@ module.exports = {
     schema: [], // Add a schema if the rule has options
     messages: {
       requiresAccessibilityLabel: "Requires accessibilityLabel",
+      suggestAddingAccessibilityLabel: "Add accessibilityLabel",
     },
   },
 
@@ -43,6 +45,21 @@ module.exports = {
             context.report({
               node,
               messageId: "requiresAccessibilityLabel",
+              suggest: [
+                {
+                  messageId: "suggestAddingAccessibilityLabel",
+                  fix: (fixer) => {
+                    const openingTagEnd = node.range[1];
+                    return fixer.insertTextBeforeRange(
+                      [
+                        openingTagEnd - (node.selfClosing ? 2 : 1),
+                        openingTagEnd,
+                      ],
+                      ` accessibilityLabel=""`
+                    );
+                  },
+                },
+              ],
             });
           }
         }

--- a/packages/eslint-plugin/lib/rules/requires-accessibility-label.js
+++ b/packages/eslint-plugin/lib/rules/requires-accessibility-label.js
@@ -35,11 +35,7 @@ module.exports = {
       JSXOpeningElement(node) {
         if (isAccessible(node) && !isText(node)) {
           if (
-            !node.attributes.some((attribute) =>
-              ["accessibilityLabel", "aria-label", "alt"].includes(
-                attribute.name.name
-              )
-            ) &&
+            !hasLabelProp(node) &&
             !hasExactlyOneChildWhichIsTextOrHasALabel(node.parent)
           ) {
             context.report({

--- a/packages/eslint-plugin/lib/utils/hasLabelProp.js
+++ b/packages/eslint-plugin/lib/utils/hasLabelProp.js
@@ -1,0 +1,13 @@
+module.exports = (element) => {
+  if (element.type === "JSXOpeningElement") {
+    return element.attributes.some((attribute) => {
+      return (
+        attribute.type === "JSXAttribute" &&
+        ["accessibilityLabel", "aria-label", "alt"].includes(
+          attribute.name.name
+        )
+      );
+    });
+  }
+  return false;
+};

--- a/packages/eslint-plugin/tests/lib/rules/requires-accessibility-label.js
+++ b/packages/eslint-plugin/tests/lib/rules/requires-accessibility-label.js
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Enforces label when component accessible
+ * @author Paul Briand
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/requires-accessibility-label"),
+  RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parser: require.resolve("@typescript-eslint/parser"),
+  parserOptions: {
+    ecmaVersion: 2021,
+    sourceType: "module",
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+const valid = [
+  `<View accessible accessibilityLabel="foo" />`,
+  `<View accessible>
+    <Text>foo</Text>
+  </View>`,
+];
+
+ruleTester.run("requires-accessibility-label", rule, {
+  valid,
+
+  invalid: [
+    {
+      code: `<View accessible />`,
+      errors: ["Requires accessibilityLabel"],
+    },
+    {
+      code: `<View accessible>
+    <Text>foo</Text>
+    <View accessible accessibilityLabel="foo" />
+  </View>`,
+      errors: ["Requires accessibilityLabel"],
+    },
+  ],
+});


### PR DESCRIPTION
[Notion Ticket](https://www.notion.so/m33/Rule-A5-require-accessibility-label-43b5e70613ab495eaa73a090fefc5514?pvs=4)

# Why

When a view is marked as accessible, it is a good practice to set an accessibilityLabel on the view, so that people who use VoiceOver know what element they have selected. If component has multiple labeled components as children, it is good practice to override accessibilityLabel as it would only concatenate the labels and make it unreadable sometimes.
