### PR TITLE
Chore/npm publish on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
         run: npx lerna bootstrap
 
       - name: Publish packages
-        run: npx lerna publish from-package --no-private
+        run: npx lerna publish from-package --no-private --yes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,10 @@
 name: Publish Packages
 on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - main
+  release:
+    types: [published]
 
 jobs:
   publish:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:
@@ -27,6 +23,6 @@ jobs:
         run: npx lerna bootstrap
 
       - name: Publish packages
-        run: npx lerna publish --conventional-commits --no-private --yes
+        run: npx lerna publish from-package --no-private
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish Packages
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  publish:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Bootstrap Lerna
+        run: npx lerna bootstrap
+
+      - name: Publish packages
+        run: npx lerna publish --conventional-commits --no-private --yes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "0.2.0"
+  "version": "independent"
 }


### PR DESCRIPTION
[Notion Ticket](https://www.notion.so/m33/Automatiser-la-publication-des-packages-de-react-native-project-config-sur-npm-32384effbd374c7d9d07917eb2b408e5?pvs=4)

# Why (EDIT)
On utilise lerna pour faire du versioning de package et la publication sur npm. On veut que les packages soient automatiquement ~versionnés et~ publiés sur npm ~au moment d'un merge sur le main~ à la publication d'une release.


# Ressources:
- [Publier les packages avec lerna](https://lerna.js.org/docs/features/version-and-publish#publishing-to-npm)
- [Github actions pour publier des packges](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages)