### PR TITLE
feat: add a11y custom rules in a11y config

### DIFF
--- a/example-app/.eslintrc
+++ b/example-app/.eslintrc
@@ -8,11 +8,6 @@
     }
   ],
   "rules": {
-    "@bam.tech/require-named-effect": "error",
-    "@bam.tech/image-requires-accessible-prop": "error",
-    "@bam.tech/do-not-use-role-on-image": "error",
-    "@bam.tech/accessibility-props-require-accessible": "error",
-    "@bam.tech/requires-accessibility-role-when-accessible": "error",
-    "@bam.tech/requires-accessibility-label": "error"
+    "@bam.tech/require-named-effect": "error"
   }
 }

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -34,7 +34,7 @@ This plugin exports multiple configurations that can be used in your `.eslintrc`
 | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [`@bam.tech/recommended`](./lib/configs/recommended.js) | The recommended config for all projects                                                                                                                      |
 | [`@bam.tech/tests`](./lib/configs/tests.js)             | The recommended config for test files. By default this applies to every file: put it in an `overrides` to filter on your test files.                         |
-| [`@bam.tech/a11y` ](./lib/configs/a11y.js)              | [beta] Eslint config to check for accessibility. Still in beta to not break existing projects, but will be merged into the recommended config in the future. |
+| [`@bam.tech/a11y`](./lib/configs/a11y.js)               | [beta] Eslint config to check for accessibility. Still in beta to not break existing projects, but will be merged into the recommended config in the future. |
 
 These configs need some peer dependencies. You can list them with:
 
@@ -54,17 +54,19 @@ This plugin exports some custom rules that you can optionally use in your projec
 
 <!-- begin auto-generated rules list -->
 
+💼 Configurations enabled in.\
+♿ Set in the `a11y` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
-| Name                                                                                                     | Description                                                     | 🔧  | 💡  |
-| :------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------- | :-- | :-- |
-| [accessibility-props-require-accessible](docs/rules/accessibility-props-require-accessible.md)           | Requires accessible prop when accessibility props are defined   | 🔧  |     |
-| [do-not-use-role-on-image](docs/rules/do-not-use-role-on-image.md)                                       | Disallow role prop on Image component                           | 🔧  |     |
-| [image-requires-accessible-prop](docs/rules/image-requires-accessible-prop.md)                           | Require accessible prop on image components                     | 🔧  | 💡  |
-| [require-named-effect](docs/rules/require-named-effect.md)                                               | Enforces the use of named functions inside a useEffect          |     |     |
-| [requires-accessibility-label](docs/rules/requires-accessibility-label.md)                               | Enforces label when component accessible                        |     | 💡  |
-| [requires-accessibility-role-when-accessible](docs/rules/requires-accessibility-role-when-accessible.md) | Enforces accessibilityRole or role when component is accessible |     | 💡  |
+| Name                                                                                                     | Description                                                     | 💼  | 🔧  | 💡  |
+| :------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------- | :-- | :-- | :-- |
+| [accessibility-props-require-accessible](docs/rules/accessibility-props-require-accessible.md)           | Requires accessible prop when accessibility props are defined   | ♿  | 🔧  |     |
+| [do-not-use-role-on-image](docs/rules/do-not-use-role-on-image.md)                                       | Disallow role prop on Image component                           | ♿  | 🔧  |     |
+| [image-requires-accessible-prop](docs/rules/image-requires-accessible-prop.md)                           | Require accessible prop on image components                     | ♿  | 🔧  | 💡  |
+| [require-named-effect](docs/rules/require-named-effect.md)                                               | Enforces the use of named functions inside a useEffect          |     |     |     |
+| [requires-accessibility-label](docs/rules/requires-accessibility-label.md)                               | Enforces label when component accessible                        | ♿  |     | 💡  |
+| [requires-accessibility-role-when-accessible](docs/rules/requires-accessibility-role-when-accessible.md) | Enforces accessibilityRole or role when component is accessible | ♿  |     | 💡  |
 
 <!-- end auto-generated rules list -->
 
@@ -75,12 +77,7 @@ To use a rule, just declare it in your `.eslintrc`:
 {
   "plugins": ["@bam.tech"],
   "rules": {
-    "@bam.tech/require-named-effect": "error",
-    "@bam.tech/image-requires-accessible-prop": "error",
-    "@bam.tech/do-not-use-role-on-image": "error",
-    "@bam.tech/accessibility-props-require-accessible": "error",
-    "@bam.tech/requires-accessibility-role-when-accessible": "error",
-    "@bam.tech/requires-accessibility-label": "error"
+    "@bam.tech/require-named-effect": "error"
   }
 }
 ```

--- a/packages/eslint-plugin/docs/rules/accessibility-props-require-accessible.md
+++ b/packages/eslint-plugin/docs/rules/accessibility-props-require-accessible.md
@@ -1,5 +1,7 @@
 # Requires accessible prop when accessibility props are defined (`@bam.tech/accessibility-props-require-accessible`)
 
+💼 This rule is enabled in the ♿ `a11y` config.
+
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
 <!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/do-not-use-role-on-image.md
+++ b/packages/eslint-plugin/docs/rules/do-not-use-role-on-image.md
@@ -1,5 +1,7 @@
 # Disallow role prop on Image component (`@bam.tech/do-not-use-role-on-image`)
 
+💼 This rule is enabled in the ♿ `a11y` config.
+
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
 <!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/image-requires-accessible-prop.md
+++ b/packages/eslint-plugin/docs/rules/image-requires-accessible-prop.md
@@ -1,5 +1,7 @@
 # Require accessible prop on image components (`@bam.tech/image-requires-accessible-prop`)
 
+💼 This rule is enabled in the ♿ `a11y` config.
+
 🔧💡 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
 <!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/requires-accessibility-label.md
+++ b/packages/eslint-plugin/docs/rules/requires-accessibility-label.md
@@ -1,5 +1,7 @@
 # Enforces label when component accessible (`@bam.tech/requires-accessibility-label`)
 
+💼 This rule is enabled in the ♿ `a11y` config.
+
 💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
 <!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/requires-accessibility-role-when-accessible.md
+++ b/packages/eslint-plugin/docs/rules/requires-accessibility-role-when-accessible.md
@@ -1,5 +1,7 @@
 # Enforces accessibilityRole or role when component is accessible (`@bam.tech/requires-accessibility-role-when-accessible`)
 
+💼 This rule is enabled in the ♿ `a11y` config.
+
 💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
 <!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/lib/configs/a11y.js
+++ b/packages/eslint-plugin/lib/configs/a11y.js
@@ -7,5 +7,10 @@ module.exports = defineConfig({
   extends: ["plugin:react-native-a11y/all"],
   rules: {
     "react-native-a11y/has-accessibility-hint": "off",
+    "@bam.tech/image-requires-accessible-prop": "error",
+    "@bam.tech/do-not-use-role-on-image": "error",
+    "@bam.tech/accessibility-props-require-accessible": "error",
+    "@bam.tech/requires-accessibility-role-when-accessible": "error",
+    "@bam.tech/requires-accessibility-label": "error",
   },
 });


### PR DESCRIPTION
No notion ticket

# Why

On ajoute les règles a11y dans la config a11y, pour maximiser l'expérimentation des règles et la boucle de feedback.
PR pour préparer la release 0.4.0