### PR TITLE
Chore/lerna changelog conventional commits

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,8 @@
 "no examples 📝":
   - all: ["packages/eslint-plugin/**/*", "!example-app/**/*"]
+
+"📏 eslint-plugin"
+  - all: ["packages/eslint-plugin/**/*","!packages/typescript-config/**/*"]
+
+"typescript-config"
+  - all: ["packages/typescript-config/**/*","!packages/eslint-plugin/**/*"]

--- a/.github/pr-conventional-title-checker-config.json
+++ b/.github/pr-conventional-title-checker-config.json
@@ -3,7 +3,7 @@
     "name": "no-conventional-pr-name"
   },
   "CHECKS": {
-    "regexp": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE){1}(([w-.]+))?(:) ([w ])+([sS]*)$",
+    "regexp": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(([w-.]+))?(:) ([w ])+([sS]*)$",
     "ignoreLabels": ["WIP"]
   },
   "MESSAGES": {

--- a/.github/pr-conventional-title-checker-config.json
+++ b/.github/pr-conventional-title-checker-config.json
@@ -3,7 +3,7 @@
     "name": "no-conventional-pr-name"
   },
   "CHECKS": {
-    "regexp": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(([w-.]+))?(:) ([w ])+([sS]*)$",
+    "regexp": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(\\!)?\\: ([\\w ])+([\\s\\S]*)",
     "ignoreLabels": ["WIP"]
   },
   "MESSAGES": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,5 +6,4 @@ Each package has its own specifications for contribution. Please refer to the `C
 
 ## Conventional commits
 
-We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to automate the release process.
-Later on, we will add a `CHANGELOG.md` file to each package, which will be automatically updated on each release.
+We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to automate the release process. Please follow the commit message format described in the link above. Lerna will automatically generate the changelog for each package based on the commit messages since the last version. (see [README.md](README.md#publishing-a-new-version-of-a-package))

--- a/README.md
+++ b/README.md
@@ -37,22 +37,21 @@ All you have to do is the versioning of the packages you want to publish.
 
 > You need to be on the main branch and have the repo write access to publish a new version.
 
-Run `yarn lerna version` to start the process. It will ask you which packages you want to publish and which version you want to publish them under.
+Run `yarn publish` to start the process. It will run the command `yarn lerna version --conventional-commits` which will prompt you to select the packages you want to publish and the version bump for each of them.
+
+Lerna will prompt you to select the version bump for each package. It will also generate the changelog for each package based on the commit messages since the last version.
+
+> Versioning and changelogs generation using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
+
+Here's an example of the output:
 
 ```bash
-? Select a new version (currently 1.0.0) (Use arrow keys)
-❯ Patch (1.0.1) # bug fixes
-  Minor (1.1.0) # new features
-  Major (2.0.0) # breaking changes
-  Prepatch (1.0.1-alpha.0)
-  Preminor (1.1.0-alpha.0)
-  Premajor (2.0.0-alpha.0)
-  Custom Prerelease
-  Custom Version
-```
+lerna info Looking for changed packages since @bam.tech/eslint-plugin@1.0.0
+lerna info getChangelogConfig Successfully resolved preset "conventional-changelog-angular"
 
-After you have selected the packages and the versions, Lerna will push a new tagged commit with the version bumps in `package.json` files.
-The pushed tag will trigger the Github Workflow which will publish the packages to NPM.
+Changes:
+ - @bam.tech/eslint-plugin: 1.0.0 => 1.1.0
+```
 
 ## Running commands
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "root",
   "private": true,
+  "scripts": {
+    "publish": "lerna version --conventional-commits --no-private"
+  },
   "workspaces": [
     "packages/*",
     "example-app"


### PR DESCRIPTION
[Notion Ticket](https://www.notion.so/m33/ETQDev-sur-plugin-eslint-quand-je-fais-une-release-github-le-changelog-est-MAJ-automatiquement-69cba93b61924f97acd595eb7e8dffe5?pvs=4)

# Why

On veut garder un changelog à jour pour suivre les packages dans le temps. 

# Changes

- ajout d'un script de versionning qui utilise `lerna version --conventional-commits` 
- MAJ du workflow "PR Conventional Title Checker" pour enlever BREAKING CHANGE de la regex, car il ne reconnait pas dans les commits squashés

# Test plan

Testés dans un repo privé