### PR TITLE
feat: add unused imports rules

### DIFF
--- a/example-app/eslint-breaking-examples/break-typescript-eslint-rules.ts
+++ b/example-app/eslint-breaking-examples/break-typescript-eslint-rules.ts
@@ -1,7 +1,0 @@
-// Save without formatting: [⌘ + K] > [S]
-
-// This should trigger two errors breaking typescript-eslint rules:
-// @typescript-eslint/no-unused-vars
-// @typescript-eslint/ban-types
-
-const str: String = "foo";

--- a/example-app/eslint-breaking-examples/break-unused-imports-rules.tsx
+++ b/example-app/eslint-breaking-examples/break-unused-imports-rules.tsx
@@ -1,0 +1,9 @@
+// Save without formatting: [⌘ + K] > [S]
+
+// This should trigger two errors breaking unused-imports rules:
+// unused-imports/no-unused-imports
+// unused-imports/no-unused-vars
+
+import { View } from "react-native";
+
+const unused_var = 1;

--- a/packages/eslint-plugin/lib/configs/recommended.js
+++ b/packages/eslint-plugin/lib/configs/recommended.js
@@ -30,7 +30,6 @@ module.exports = defineConfig({
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/indent": "off",
     "@typescript-eslint/no-explicit-any": "error",
-    "@typescript-eslint/no-unused-vars": "error",
     "no-console": ["error", { allow: ["warn", "error"] }],
     "no-return-await": "error",
     "react-hooks/exhaustive-deps": "error",
@@ -39,7 +38,9 @@ module.exports = defineConfig({
     "react/no-unstable-nested-components": "error",
     "react/prop-types": "off",
     "react/no-unused-prop-types": "error",
+    "@typescript-eslint/no-unused-vars": "off",
     "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": "error",
   },
   env: {
     node: true,


### PR DESCRIPTION
[Notion Ticket](https://www.notion.so/m33/ETQDev-sur-un-projet-utilisant-la-config-ESlint-quand-un-import-est-inutilis-eslint-me-le-signa-4c70f654998f4c268e56a75a06f83cfa?pvs=4)

# Why

Sur le plugin, on utilise actuellement `"@typescript-eslint/no-unused-vars": "error",` pour entre autre détecter les imports inutilisés.

Sur les projets, on utilise souvent [eslint-plugin-unused-imports](https://github.com/sweepline/eslint-plugin-unused-imports) qui fait la même chose mais propose un auto-fix (beaucoup plus utile)

# Changes

- disabled `@typescript-eslint/no-unused-vars`
- add `"unused-imports/no-unused-vars": "error"`

# Test plan

- ajout d'un fichier breaking dans `example-app`