### PR TITLE
chore: update lerna config

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ All you have to do is the versioning of the packages you want to publish.
 
 > You need to be on the main branch and have the repo write access to publish a new version.
 
-Run `yarn publish` to start the process. It will run the command `yarn lerna version --conventional-commits` which will prompt you to select the packages you want to publish and the version bump for each of them.
+Run `yarn lerna version` to start the process. It will run the command `yarn lerna version --conventional-commits --no-private`.
 
 Lerna will prompt you to select the version bump for each package. It will also generate the changelog for each package based on the commit messages since the last version.
 
@@ -52,6 +52,8 @@ lerna info getChangelogConfig Successfully resolved preset "conventional-changel
 Changes:
  - @bam.tech/eslint-plugin: 1.0.0 => 1.1.0
 ```
+
+It will then push a tagged commit `chore(release): Publish` which will then trigger the Github Workflow to publish the new version of each package to NPM.
 
 ## Running commands
 

--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,10 @@
   "packages": ["packages/*"],
   "command": {
     "version": {
-      "noPrivate": true
+      "private": false,
+      "message": "chore(release): Publish",
+      "conventionalCommits": true,
+      "allowBranch": "main"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "root",
   "private": true,
-  "scripts": {
-    "publish": "lerna version --conventional-commits --no-private"
-  },
   "workspaces": [
     "packages/*",
     "example-app"


### PR DESCRIPTION
# Why

Dans les dernière PR j'ai ajouté un script `publish` dans package.json pour exécuter la commande lerna version. Mais [`yarn publish`](https://classic.yarnpkg.com/lang/en/docs/cli/publish/) ne peut pas être overriden. 

# Changes
- dans `lerna.json`, ajout des options `private: false`, `conventionalCommits: true`, `allowBranche: 'main'` et le message de commit au versionning
- dans `package.json` suppression du script publish
- dans `README.md` revert la section publishing pour préciser le lancement de `yarn lerna version`