### PR TITLE
fix: disable react-native/no-raw-text

### DIFF
--- a/packages/eslint-plugin/lib/configs/recommended.js
+++ b/packages/eslint-plugin/lib/configs/recommended.js
@@ -36,6 +36,7 @@ module.exports = defineConfig({
     "react-hooks/exhaustive-deps": "error",
     "react-native/no-color-literals": "off",
     "react-native/sort-styles": "off",
+    "react-native/no-raw-text": "off",
     "react/no-unstable-nested-components": "error",
     "react/prop-types": "off",
     "react/no-unused-prop-types": "error",


### PR DESCRIPTION
[Dantotsu](https://www.notion.so/m33/D-now-raw-text-rule-enabled-9d58eca3fc004a63a3e4ddbbe367f821?pvs=4)

`react-native/no-raw-text` should have been disabled in PR #54. But it is still enabled as it is in `react-native/all` config.

