### PR TITLE
docs(eslint-plugin): adding rules link

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -2,6 +2,8 @@
 
 This project is an ESLint plugin that gathers all the rules, plugins and parsers that should be used in any new react-native BAM project.
 
+The list of rules and configuration details can be found [`here`](https://github.com/bamlab/react-native-project-config/blob/main/packages/eslint-plugin/lib/configs/recommended.js).
+
 ## Quick Setup
 
 Install the plugin and its peer dependencies:

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -18,8 +18,7 @@
   "license": "MIT",
   "scripts": {
     "lint": "npm-run-all \"lint:*\"",
-    "lint:js": "eslint .",
-    "test": "mocha tests --recursive"
+    "lint:js": "eslint ."
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.61.0",


### PR DESCRIPTION
[Ticket notion](https://www.notion.so/m33/ETQU-Dans-la-doc-NPM-du-plugin-j-ai-un-passage-explicite-vers-les-r-gles-overrid-es-dans-le-plugin-7691670a9d6d49108ccdd2aa811f9b49)

Adding a direct link to rule configuration at the top of the readme