### PR TITLE
remove useless required line

### DIFF
--- a/packages/eslint-plugin/lib/index.js
+++ b/packages/eslint-plugin/lib/index.js
@@ -4,5 +4,4 @@ const requireIndex = require("requireindex");
 
 module.exports = {
   configs: requireIndex(__dirname + "/configs"),
-  rules: requireIndex(__dirname + "/rules"),
 };


### PR DESCRIPTION
Fix error : 
```Error: Failed to load plugin '@bam.tech' declared in 'package.json » ./frontend': ENOENT: no such file or directory, scandir '/Users/nissimc/Desktop/Projects/IndiaFirst/newsapp/node_modules/@bam.tech/eslint-plugin/lib/rules'```

The `rules` directory has been deleted few days ago but was still required in the es-lint `index.js`