### PR TITLE
feat: Add npm relative information to readme file

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
 <!-- If your PR is related to a RFC, please add `Closes #<issue number>` to link the PR to the issue and close it automatically when the PR is merged -->
 
-<!-- We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to automate the release process. Please follow the commit message format described in the link above. Lerna will automatically generate the changelog for each package based on the commit messages since the last version. -->
+<!-- We use conventional commits to automate the release process. Please read the [Readme](https://github.com/bamlab/react-native-project-config/blob/main/README.md) for more information. Please follow the commit message format described in the link above. Lerna will automatically generate the changelog for each package based on the commit messages since the last version. -->

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ It will then push a tagged commit `chore(release): Publish` which will then trig
 
 > If you add a new rule to a config, this is a breaking change, because it could make the CI fail on projects that use the plugin. The commit name where you add the new rule needs to follow this patern `BREAKING CHANGE : the description of your commit`
 
+## Unpublish a package version
+
+If you want to unpublish a package, you have to be contributor of @bam.tech/eslint-plugin (in this case for the eslint plugin). Use the following commad :
+`npm unpublish @bam.tech/eslint-plugin@X.Y.Z`
+
 ## Conventional commits
 
 We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to automate the release process.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Here are some useful commands:
 - rename the directory of a package: `mv package-my-config new-directory-name && yarn lerna bootstrap`,
 - run a script `do-something` that exists in at least one package: `yarn lerna run do-something` (this will try to run the script in all packages in which it is defined).
 
+## Conventional commits
+
+We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to automate the release process.
+
+> If you add a new rule to a config, this is a breaking change, because it could make the CI fail on projects that use the plugin. The commit name where you add the new rule needs to follow this patern `BREAKING CHANGE : the description of your commit`
+
 ## Publishing a new version of a package
 
 The publication is done automatically by this [Github Workflow](https://github.com/bamlab/react-native-project-config/blob/main/.github/workflows/publish.yml) when a new tag is pushed to the repository.
@@ -59,12 +65,6 @@ It will then push a tagged commit `chore(release): Publish` which will then trig
 
 If you want to unpublish a package, you have to be contributor of @bam.tech/eslint-plugin (in this case for the eslint plugin). Use the following commad :
 `npm unpublish @bam.tech/eslint-plugin@X.Y.Z`
-
-## Conventional commits
-
-We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to automate the release process.
-
-> If you add a new rule to a config, this is a breaking change, because it could make the CI fail on projects that use the plugin. The commit name where you add the new rule needs to follow this patern `BREAKING CHANGE : the description of your commit`
 
 ## Running commands
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ Changes:
 
 It will then push a tagged commit `chore(release): Publish` which will then trigger the Github Workflow to publish the new version of each package to NPM.
 
-> If you add a new rule to a config, this is a breaking change, because it could make the CI fail on projects that use the plugin. The commit name where you add the new rule needs to follow this patern `BREAKING CHANGE : the description of your commit`
-
 ## Unpublish a package version
 
 If you want to unpublish a package, you have to be contributor of @bam.tech/eslint-plugin (in this case for the eslint plugin). Use the following commad :
@@ -65,6 +63,8 @@ If you want to unpublish a package, you have to be contributor of @bam.tech/esli
 ## Conventional commits
 
 We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to automate the release process.
+
+> If you add a new rule to a config, this is a breaking change, because it could make the CI fail on projects that use the plugin. The commit name where you add the new rule needs to follow this patern `BREAKING CHANGE : the description of your commit`
 
 ## Running commands
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ It will then push a tagged commit `chore(release): Publish` which will then trig
 
 > If you add a new rule to a config, this is a breaking change, because it could make the CI fail on projects that use the plugin. The commit name where you add the new rule needs to follow this patern `BREAKING CHANGE : the description of your commit`
 
+## Conventional commits
+
+We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to automate the release process.
+
 ## Running commands
 
 - `yarn lerna run start`: run the 'start' script in all packages (currently only present in `example-app`),


### PR DESCRIPTION
<!-- If your PR is related to a RFC, please add `Closes #<issue number>` to link the PR to the issue and close it automatically when the PR is merged -->

[Changer le lien par défaut dans github pour qu’il renvoie vers le readme](https://www.notion.so/m33/Changer-le-lien-par-d-faut-dans-github-pour-qu-il-renvoie-vers-le-readme-0433a19e54ce4f499b4b168eac83e61a?pvs=4)
[Ajouter une info sur comment unpublish un package npm dans le Readme](https://www.notion.so/m33/Ajouter-une-info-sur-comment-unpublish-un-package-npm-dans-le-Readme-64c09509a0a74e16866356fdbd55eb27?pvs=4)
[Modifier le readme pour mettre la partie relative à add une rule ⇒ breaking change](https://www.notion.so/m33/Modifier-le-readme-pour-mettre-la-partie-relative-add-une-rule-breaking-change-729e36206a77452a8c530e14f71ffa8e?pvs=4)

<!-- We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to automate the release process. Please follow the commit message format described in the link above. Lerna will automatically generate the changelog for each package based on the commit messages since the last version. -->
