### PR TITLE
fix: remove useWorkspaces from lerna config

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "useWorkspaces": true,
   "version": "independent",
   "packages": ["packages/*"],
   "command": {


### PR DESCRIPTION
<!-- If your PR is related to a RFC, please add `Closes #<issue number>` to link the PR to the issue and close it automatically when the PR is merged -->

Lerna version was bump in a renovate's pr and now the command `lerna version` fails because `useWorkspaces` option has been deprecated. it should work automatically with the config in the root's package.json

<!-- We use conventional commits to automate the release process. Please read the [Readme](https://github.com/bamlab/react-native-project-config/blob/main/README.md) for more information. Please follow the commit message format described in the link above. Lerna will automatically generate the changelog for each package based on the commit messages since the last version. -->
