### PR TITLE
fix: run build command in eslint plugin workspace

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Install dependencies
         run: yarn --immutable
 
-      - name: Build
-        run: yarn build
+      - name: Build eslint-plugin
+        run: yarn workspace @bam.tech/eslint-plugin build
 
       - name: Set up .npmrc file
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc


### PR DESCRIPTION
<!-- If your PR is related to a RFC, please add `Closes #<issue number>` to link the PR to the issue and close it automatically when the PR is merged -->

build command is run at the root where it's not found, this fixes it by running the command in the correct workspace

<!-- We use conventional commits to automate the release process. Please read the [Readme](https://github.com/bamlab/react-native-project-config/blob/main/README.md) for more information. Please follow the commit message format described in the link above. Lerna will automatically generate the changelog for each package based on the commit messages since the last version. -->
