### PR TITLE
fix: dependencies

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -28,6 +28,7 @@
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "eslint": "^8.44.0",
+    "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-jest": "^27.2.2",
     "eslint-plugin-jest-formatting": "^3.1.0",
     "eslint-plugin-prettier": "^5.0.0",
@@ -40,15 +41,14 @@
     "prettier": "^3.0.0"
   },
   "dependencies": {
-    "@typescript-eslint/parser": "^6.0.0",
-    "eslint-config-prettier": "^9.0.0",
-    "eslint-define-config": "^1.21.0",
-    "requireindex": "^1.2.0"
+    "eslint-define-config": "^1.21.0"
   },
   "devDependencies": {
     "@types/eslint": "^8.44.7",
+    "@typescript-eslint/parser": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "eslint": "^8.44.0",
+    "eslint-config-prettier": "^9.0.0",
     "eslint-doc-generator": "^1.4.3",
     "eslint-plugin-eslint-plugin": "^5.1.0",
     "eslint-plugin-jest": "^27.2.2",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -26,18 +26,18 @@
     "update:eslint-docs": "eslint-doc-generator --config-emoji tests,🧪"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.61.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
     "eslint": "^8.44.0",
     "eslint-plugin-jest": "^27.2.2",
     "eslint-plugin-jest-formatting": "^3.1.0",
-    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-native": "^4.0.0",
     "eslint-plugin-react-native-a11y": "^3.3.0",
     "eslint-plugin-testing-library": "^6.0.1",
     "eslint-plugin-unused-imports": "^3.0.0",
-    "prettier": "^2.8.8"
+    "prettier": "^3.0.0"
   },
   "dependencies": {
     "@typescript-eslint/parser": "^6.0.0",
@@ -57,6 +57,7 @@
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-native": "^4.0.0",
+    "eslint-plugin-react-native-a11y": "^3.3.0",
     "eslint-plugin-testing-library": "6.0.1",
     "eslint-plugin-unused-imports": "^3.0.0",
     "jest": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9771,11 +9771,6 @@ requireg@^0.2.2:
     rc "~1.2.7"
     resolve "~1.7.1"
 
-requireindex@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz"
-  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
-
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4889,7 +4889,7 @@ eslint-plugin-react-hooks@^4.6.0:
 
 eslint-plugin-react-native-a11y@^3.3.0:
   version "3.3.0"
-  resolved "https://registry.npmjs.org/eslint-plugin-react-native-a11y/-/eslint-plugin-react-native-a11y-3.3.0.tgz"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-native-a11y/-/eslint-plugin-react-native-a11y-3.3.0.tgz#0485a8f18474bf54ec68d004b50167f75ffbf201"
   integrity sha512-21bIs/0yROcMq7KtAG+OVNDWAh8M+6scII0iXcO3i9NYHe2xZ443yPs5KSUMSvQJeRLLjuKB7V5saqNjoMWDHA==
   dependencies:
     "@babel/runtime" "^7.15.4"


### PR DESCRIPTION
<!-- If your PR is related to a RFC, please add `Closes #<issue number>` to link the PR to the issue and close it automatically when the PR is merged -->

We had a bug on Safran because the plugin has a version of @typescript-eslint/parser that does not match the one we have on our project. It was a dependency but it should be a peer dep like other packages. 

There were other issues, some peer deps were not the same as dev deps, this is because renovate updated some dev deps but did not update peer deps as well. Finally some peer deps were not included in dev deps (a11y plugin) which was fine because it's not tested at all but it would have been problematic otherwise

<!-- We use conventional commits to automate the release process. Please read the [Readme](https://github.com/bamlab/react-native-project-config/blob/main/README.md) for more information. Please follow the commit message format described in the link above. Lerna will automatically generate the changelog for each package based on the commit messages since the last version. -->
